### PR TITLE
Remove fake package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cagrex"
-version = "0.1.0"
-description = ""
+version = "0.4.3"
+description = "CAGR Explorer"
 authors = ["Caravela Hacker Club"]
 
 [tool.poetry.dependencies]
@@ -9,7 +9,6 @@ python = "^3.7"
 requests = "^2.22"
 mechanicalsoup = "^0.11.0"
 bs4 = "^0.0.1"
-pprint = "^0.1.0"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Esse pacote `pprint` que tá nas dependências aparentemente é um pacote falso que não implementa nada. (vide https://pypi.org/project/pprint/)
Manter ele como dependência é uma vulnerabilidade.

O `pprint` que o cagrex depende é parte da stdlib (https://docs.python.org/3/library/pprint.html).